### PR TITLE
Support gitalk comment system

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -100,6 +100,7 @@
                      {{ template "_internal/disqus.html" . }}
                  {{ end }}
           {{ end }}
+        {{ partial "gitalk.html" . }}
     </div>
 </article>
 {{- end }}

--- a/layouts/partials/gitalk.html
+++ b/layouts/partials/gitalk.html
@@ -1,0 +1,24 @@
+{{ if .Site.Params.enableGitalk }}
+<div id="gitalk-container"></div>
+<link rel="stylesheet" href="https://unpkg.com/gitalk/dist/gitalk.css">
+<script src="https://unpkg.com/gitalk/dist/gitalk.min.js"></script>
+<script>
+    const gitalk = new Gitalk({
+
+        clientID: '{{ .Site.Params.Gitalk.clientID }}',
+        clientSecret: '{{ .Site.Params.Gitalk.clientSecret }}',
+        repo: '{{ .Site.Params.Gitalk.repo }}',
+        owner: '{{ .Site.Params.Gitalk.owner }}',
+        admin: ['{{ .Site.Params.Gitalk.owner }}'],
+        id: location.pathname, // Ensure uniqueness and length less than 50
+        distractionFreeMode: false // Facebook-like distraction free mode
+    });
+    (function () {
+        if (["localhost", "127.0.0.1"].indexOf(window.location.hostname) != -1) {
+            document.getElementById('gitalk-container').innerHTML = 'Gitalk comments not available by default when the website is previewed locally.';
+            return;
+        }
+        gitalk.render('gitalk-container');
+    })();
+</script>
+{{ end }}


### PR DESCRIPTION
支持 [gitalk](https://github.com/gitalk/gitalk/) 评论系统

gitalk 是一个利用 GitHub API 和 GitHub issues 搭建的评论系统

## Usage

1. 申请一个 OAuth App，参考 [创建 GitHub OAuth Application](https://mogeko.me/2018/024/#%E5%88%9B%E5%BB%BA-github-application)
2. 在 `config.toml` 中添加并配置 gitalk 的相关配置
```toml
    [params]
      enableGitalk = true
    [params.gitalk] 
        clientID = "[Client ID]" # Your client ID
        clientSecret = "[Client Secret]" # Your client secret
        repo = "mogeko.github.io" # The repo to store comments
        owner = "Mogeko" # Your GitHub ID
        admin= "Mogeko" # Required. Github repository owner and collaborators. (Users who having write access to this repository)
        id= "location.pathname" # The unique id of the page.
        labels= "gitalk" # Github issue labels. If you used to use Gitment, you can change it
        perPage= 15 # Pagination size, with maximum 100.
        pagerDirection= "last" # Comment sorting direction, available values are 'last' and 'first'.
        createIssueManually= false # If it is 'false', it is auto to make a Github issue when the administrators login.
        distractionFreeMode= false # Enable hot key (cmd|ctrl + enter) submit comment.
```

效果：
![效果](https://user-images.githubusercontent.com/26341224/58398190-d0e2ac80-8086-11e9-9e02-062ade5f5a85.png)
