### PR TITLE
Support word count

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -20,6 +20,7 @@
                         {{ end }}
                 </span>
                 {{- end }}
+                <span class="post-word-count">, {{ .WordCount }} words</span>
         </div>
     </header>
     <div class="post-content">

--- a/layouts/partials/home_post.html
+++ b/layouts/partials/home_post.html
@@ -47,7 +47,8 @@
                         {{ end -}}
                         {{ end }}
                 </span>
-                {{- end }}
+								{{- end }}
+								<span class="post-word-count">, {{ .WordCount }} words</span>
         </div>
 				{{ with .Params.tags }}
 				<div class="post-tags">


### PR DESCRIPTION
支持字数统计

Hugo 默认是不统计中文的，需要在 `config.toml` 中开启

```toml
hasCJKLanguage = true # 开启可以让「字数统计」统计汉字
```

效果

![效果](https://mogeko.me/blog-images/r/033/fix_bug.png)